### PR TITLE
Add in mill-github-dependency-graph

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -204,7 +204,7 @@
 - circe/circe-spire
 - circe/circe-spray
 - circe/circe-yaml
-- ckipp01/tooling-talks
+- ckipp01/mill-github-dependency-graph
 - CleverCloud/akka-warp10-scala-client
 - clovellytech/http4s-modules
 - codacy/codacy-analysis-cli


### PR DESCRIPTION
This removes my old repo, which is now a scala-cli project, and instead adds a new Mill one.