### PR TITLE
remove somind

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1203,7 +1203,6 @@
 - snowplow/snowplow-rdb-loader
 - solidninja/albion
 - solidninja/schema-registry-sttp-client
-- SoMind/authz-verify-proxy
 - soundcloud/twinagle
 - spf3000/functional-kniffle
 - spotify/big-data-rosetta-code


### PR DESCRIPTION
I missed this one when removing for the local scala steward support for dtlab.