### PR TITLE
Remove scalajs-interactjs

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -160,7 +160,6 @@
 - build-server-protocol/build-server-protocol
 - buntec/ff4s
 - Bunyod/PracticalFPinScala
-- busti/scalajs-interactjs
 - BusyByte/flutterby
 - butcherless/incubator
 - butcherless/scala


### PR DESCRIPTION
Library will be superseded with a soft wrapper around scalablytyped.