### PR TITLE
Remove tofu

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1327,8 +1327,6 @@
 - TobiasRoland/scala-xml-encoder
 - toddburnside/scalajs-react-table
 - toddburnside/scalajs-react-virtuoso
-- tofu-tf/derevo
-- tofu-tf/tofu
 - tomwadeson/scala-barebones
 - topl/bifrost:dev
 - ToToTec/CmdOption


### PR DESCRIPTION
Since tofu has it's own tofu-bot instance of SS, it's not needed anymore to receive updates from this one.