### PR TITLE
Remove bot4s

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -153,8 +153,6 @@
 - blemale/scaffeine
 - blended-zio/blended-zio
 - blindnet-io/blindsend-server
-- bot4s/telegram
-- bot4s/zmatrix
 - BotTech/scala2plantuml
 - bpholt/java-time-literals
 - brbrown25/macros


### PR DESCRIPTION
I don't need to use this instance of scala-steward anymore. Thanks for all the work