### PR TITLE
Remove coursier/sbt-cs-publish from repo list

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -251,7 +251,6 @@
 - coursier/interface
 - coursier/jni-utils
 - coursier/sbt-coursier
-- coursier/sbt-cs-publish
 - coursier/sbt-launcher
 - coursier/sbt-runner
 - coursier/sbt-shading


### PR DESCRIPTION
This repository is deprecated, and should likely be archived in the near future.