### PR TITLE
Remove coursier/sbt-launcher from repo list

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -252,7 +252,6 @@
 - coursier/jni-utils
 - coursier/sbt-coursier
 - coursier/sbt-cs-publish
-- coursier/sbt-launcher
 - coursier/sbt-runner
 - coursier/sbt-shading
 - cquiroz/kuyfi


### PR DESCRIPTION
This repo is about to be archived.