### PR TITLE
Add spotify/gcs-tools repo

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1231,6 +1231,7 @@
 - spotify/big-data-rosetta-code
 - spotify/elitzur
 - spotify/featran
+- spotify/gcs-tools
 - spotify/magnolify
 - spotify/noether
 - spotify/ratatool


### PR DESCRIPTION
Adding https://github.com/spotify/gcs-tools to list of repos managed by scala-steward