### PR TITLE
Remove xerial/sbt-pack, sbt-sonatype from the list

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1424,8 +1424,6 @@
 - wiringbits/wiringbits-webapp-utils
 - wjglerum/bamboesmanager
 - xencura/kagera
-- xerial/sbt-pack
-- xerial/sbt-sonatype
 - yannick-cw/elastic-indexer4s
 - yannick-cw/sjq
 - YannMoisan/graphite4s


### PR DESCRIPTION
We are now running our own scala-steward for maintaining these projects at https://github.com/xerial/scala-steward-repos/blob/main/repos.md

Thanks for the scala-steward support so far. Very much appreciated