### PR TITLE
Remove skunk, natchez

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1341,8 +1341,6 @@
 - to-ithaca/libra
 - tpolecat/atto
 - tpolecat/doobie
-- tpolecat/natchez
-- tpolecat/skunk
 - trace4cats/trace4cats
 - trace4cats/trace4cats-avro
 - trace4cats/trace4cats-avro-kafka


### PR DESCRIPTION
The repos were moved to Typelevel and now under care of Typlevel Steward.

https://github.com/typelevel/skunk
https://github.com/typelevel/natchez