### PR TITLE
Remove davenverse repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -292,8 +292,6 @@
 - data-tools/big-data-types
 - davegurnell/bridges
 - davegurnell/unindent
-- davenverse/cats-effect-time
-- davenverse/cats-scalacheck
 - DavidGregory084/mill-tpolecat
 - deanwampler/programming-scala-book-code-examples
 - debasishg/effRedis


### PR DESCRIPTION
We've setup our own steward for the org.

https://github.com/davenverse/steward