### PR TITLE
Update circe-magnolia from redirect org to direct owner

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -211,7 +211,6 @@
 - circe/circe-iteratee
 - circe/circe-jackson
 - circe/circe-json-schema
-- circe/circe-magnolia
 - circe/circe-optics
 - circe/circe-schema
 - circe/circe-spire
@@ -1425,6 +1424,7 @@
 - vmunier/play-scalajs.g8
 - vmunier/sbt-web-scalajs
 - vmunier/scalajs-scripts
+- vpavkin/circe-magnolia
 - Vyxal/Vyxal:version-3
 - waylayio/influxdb-scala
 - waylayio/kairosdb-scala


### PR DESCRIPTION
Circe magnolia was moved from the circe org to vpavkin and has just been redirecting for a while.  This just moves the reference to the direct place.