### PR TITLE
Remove aws-cdk-scala

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -803,7 +803,6 @@
 - nevillelyh/parquet-extra
 - nevillelyh/protobuf-generic
 - nevillelyh/shapeless-datatype
-- NickBurkard/aws-cdk-scala
 - nigeleke/cribbage:develop
 - nigeleke/flac4s:develop
 - nigeleke/life:develop


### PR DESCRIPTION
I'm archiving this repository, no need to update dependencies for it anymore. 😄