### PR TITLE
Remove lihaoyi/scala.rx

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -687,7 +687,6 @@
 - lightbend/paradox
 - lightbend/sbt-paradox-apidoc
 - lightbend/ssl-config
-- lihaoyi/scala.rx
 - limansky/beanpuree
 - liquibase4s/liquibase4s
 - liuhongchao/debug4s


### PR DESCRIPTION
Removing, because we don't have an automatic PR merging setup: https://github.com/lihaoyi/scala.rx/issues/157