### PR TITLE
Remove pekko-http-cors

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -697,7 +697,6 @@
 - loicknuchel/TypedAPI
 - lolgab/mill-mima
 - lomigmegard/akka-http-cors
-- lomigmegard/pekko-http-cors
 - lorandszakacs/enclosure
 - LPTK/simple-sub
 - lqhuang/watcher


### PR DESCRIPTION
The [pekko-http-cors](https://github.com/lomigmegard/pekko-http-cors) project is being merged into upstream Apache repository (PR https://github.com/apache/incubator-pekko-http/pull/208). 