### PR TITLE
Remove guardian-for-apache-kafka

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -26,7 +26,6 @@
 - agustafson/cats-quartz
 - ahjohannessen/sec
 - ahjohannessen/unum
-- aiven/guardian-for-apache-kafka
 - akka/akka
 - akka/akka-grpc
 - akka/akka-grpc-sample-kubernetes-scala


### PR DESCRIPTION
We have decided to use our own instance (see https://github.com/aiven/guardian-for-apache-kafka/pull/443)