### PR TITLE
remove raw-labs/snapi

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1006,7 +1006,6 @@
 - quafadas/scautable
 - qwbarch/snowflake4s
 - raboof/sbt-reproducible-builds
-- raw-labs/snapi
 - rayrobdod/string-context-parser-combinator
 - rcmartins/blinky
 - reactific/riddl


### PR DESCRIPTION
Because we use a lot of secrets in our CI we will have to run our own scala-steward instance. Since when a pull request is coming from a fork github secrets are not available and we want to keep it that way.
Thanks a lot still for the great work