### PR TITLE
Remove `fs2-kafka` 2.x series

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -425,7 +425,6 @@
 - Fabszn/scaffolding-plugin-lagom
 - Facsimiler/facsimile
 - fbaierl/scalajs-i18n-rx
-- fd4s/fs2-kafka:series/2.x
 - fd4s/fs2-kafka:series/3.x
 - fd4s/vulcan
 - fdietze/bench


### PR DESCRIPTION
2.x series is marked EOL and we don't need more Scala Steward PRs for it ✂️