### PR TITLE
Remove `fs2-kafka` 2.x series

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -428,7 +428,6 @@
 - Fabszn/scaffolding-plugin-lagom
 - Facsimiler/facsimile
 - fbaierl/scalajs-i18n-rx
-- fd4s/fs2-kafka:series/2.x
 - fd4s/fs2-kafka:series/3.x
 - fd4s/vulcan
 - fdietze/bench


### PR DESCRIPTION
2.x series is [marked EOL](https://github.com/fd4s/fs2-kafka/pull/1248) and we don't need more Scala Steward PRs for it ✂️