### PR TITLE
Update stac4s org

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -113,7 +113,6 @@
 - avdv/scalals
 - AVSystem/scala-commons
 - azavea/franklin
-- azavea/stac4s
 - azhur/kafka-serde-scala
 - Baeldung/scala-tutorials
 - balhoff/arachne
@@ -1258,6 +1257,7 @@
 - spotify/tfreader
 - srenault/sre-api
 - sritchie/scala-rl
+- stac-utils/stac4s
 - starlake-ai/starlake
 - streetcontxt/kcl-akka-stream
 - stripe/dagon


### PR DESCRIPTION
This PR changes the stac4s org, it's been migrated from azavea to stac-utils! (https://github.com/azavea/stac4s)