### PR TITLE
Remove deprecated `scala-cli` repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1140,9 +1140,6 @@
 - scalapb/zio-grpc
 - scala-bones/bones
 - scala-bones/scatonic-ideal
-- scala-cli/scalafmt-native-image
-- scala-cli/scala-cli-signing
-- scala-cli/scala-js-cli
 - scala-graph/scala-graph
 - scala-js/scala-js-dom
 - scala-js/scala-js-macrotask-executor


### PR DESCRIPTION
all of these are deprecated and no longer maintained in favor of their https://github.com/VirtusLab equivalents
https://github.com/scala-cli/scalafmt-native-image
https://github.com/scala-cli/scala-cli-signing
https://github.com/scala-cli/scala-js-cli

Moreover, the following `scala-steward` repos need updating to a new fork:
https://github.com/scala-steward/scala-cli-signing
https://github.com/scala-steward/scala-js-cli