### PR TITLE
Remove legacy `scalafmt-native-image`

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -55,7 +55,6 @@
 - alexarchambault/plotly-scala
 - alexarchambault/sbt-coursier-export
 - alexarchambault/scalacheck-shapeless
-- alexarchambault/scalafmt-native
 - alexarchambault/windows-ansi
 - alexbalonperin/zio_experiments
 - AlexITC/chrome-scalajs-template


### PR DESCRIPTION
The legacy `scala-steward` repo also needs to be removed: https://github.com/scala-steward/scalafmt-native