### PR TITLE
Add Späti to repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -581,6 +581,7 @@
 - jczuchnowski/zio-pulsar
 - jd557/interim
 - jd557/minart
+- jd557/spaeti
 - jirkavrba/vse-verification-bot
 - jkobejs/endpoints-uzhttp
 - jkobejs/zio-google-cloud-oauth2


### PR DESCRIPTION
Project: https://github.com/JD557/spaeti

For reference, this is a Scala CLI project.
My understanding is that this is now supported, but feel free to close the PR if I'm mistaken.