### PR TITLE
Add play-silhouette 9.x branch

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -979,6 +979,7 @@
 - playframework/play-scala-seed.g8
 - playframework/play-scala-seed.g8:2.9.x
 - playframework/play-silhouette
+- playframework/play-silhouette:9.x
 - playframework/play-slick
 - playframework/play-slick:5.2.x
 - playframework/play-soap


### PR DESCRIPTION
We have a 9.x branch for Play 2.9 support: https://github.com/playframework/play-silhouette/releases/tag/9.0.0

Thanks!