### PR TITLE
Remove workbenchlibs from repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -168,7 +168,6 @@
 - brbrown25/testcontainers-scala-kafka-utils
 - broadinstitute/cromwell 
 - broadinstitute/poolq
-- broadinstitute/workbench-libs
 - brsyuksel/xurl
 - buildo/retro
 - build-server-protocol/build-server-protocol


### PR DESCRIPTION
Remove broadinstitute/workbenchlibs from the list as oour team no longer wants to have scala-steward PRs generated via this process