### PR TITLE
Add `sbt/sbt-paradox-material-theme`

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1153,6 +1153,7 @@
 - sbt/sbt-multi-jvm
 - sbt/sbt-native-packager
 - sbt/sbt-osgi
+- sbt/sbt-paradox-material-theme
 - sbt/sbt-pull-request-validator
 - sbt/sbt-rjs
 - sbt/sbt-stylus


### PR DESCRIPTION
Please come visit!

We just transferred the repo to the sbt GitHub organization and will publish new releases under its groupId:
- https://github.com/sbt/sbt-paradox-material-theme
- https://github.com/sbt/sbt-paradox-material-theme/pull/34#issuecomment-1919400459
- https://github.com/scala-steward-org/scala-steward/pull/3281