### PR TITLE
Remove zio-prelude

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1607,7 +1607,6 @@
 - zio/zio-nio
 - zio/zio-openai
 - zio/zio-parser
-- zio/zio-prelude
 - zio/zio-process
 - zio/zio-profiling
 - zio/zio-project-seed.g8


### PR DESCRIPTION
It's managed by our own scala-steward bot now :)