### PR TITLE
Add play-samples main branch

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1004,6 +1004,7 @@
 - playframework/play-mailer
 - playframework/play-mailer:9.0.x
 - playframework/play-meta
+- playframework/play-samples:main
 - playframework/play-samples
 - playframework/play-samples:2.9.x
 - playframework/play-scala-angular-seed


### PR DESCRIPTION
Currently 3.0.x is the default branch because this the branch with the samples of the latest stable Play release (which is 3.0.2).
The main branch is used for development, but is not our default branch because it's unstable and it's not what people are looking for when the want to try play sample applications.
See https://github.com/playframework/play-samples/branches/all