### PR TITLE
chore: Add stale repo detection

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -4,7 +4,6 @@
 - 2m/history-of-fishing
 - 2m/kabrioletas
 - 2m/polyfact
-- 2m/rallyeye
 - 2m/sonatype-stats
 - 2m/untappd-history
 - 2m/vilnius-pub


### PR DESCRIPTION
We can now check if there are no open Scala Steward PRs in order to check that we might have problem in the repo.

And also remove one repo, which uses their own bot