### PR TITLE
Remove scala-uri (no longer maintained)

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -532,7 +532,6 @@
 - leigh-perry/metamorphosis
 - lemastero/scala_typeclassopedia
 - lemastero/Triglav
-- lemonlabsuk/scala-uri
 - lensesio/stream-reactor
 - leobenkel/Laeta
 - leobenkel/Soteria


### PR DESCRIPTION
Removing scala-uri as I'm no longer actively maintaining that project (see notice at the top of the project README: https://github.com/lemonlabsuk/scala-uri)