### PR TITLE
Remove caliban-gitlab

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -721,7 +721,6 @@
 - Philippus/scala-isbn
 - Philippus/zio-pekko-cluster
 - Philippus/zio-pekko-cluster:series/1.x
-- pitgull/pitgull
 - pityka/lamp
 - pityka/nspl
 - pityka/pairwisealignment

--- a/repos-github.md
+++ b/repos-github.md
@@ -797,7 +797,6 @@
 - plokhotnyuk/rtree2d
 - pme123/camundala
 - polyvariant/better-tostring
-- polyvariant/caliban-gitlab
 - polyvariant/colorize-scala
 - polyvariant/sttp-oauth2
 - ppurang/abctemplates


### PR DESCRIPTION
We don't maintain these repos anymore.