### PR TITLE
Add `sbt/setup-sbt`

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -910,6 +910,7 @@
 - sbt/sbt-web
 - sbt/sbt-web-build-base
 - sbt/zinc
+- sbt/setup-sbt
 - ScalablyTyped/Converter
 - ScalaConsultants/mesmer-akka-agent
 - ScalaConsultants/zio-akka-quickstart.g8


### PR DESCRIPTION
@eed3si9n @SethTisue good to go?

Btw I would also want to inquire whether changes are needed at `sbt/setup-sbt` too. I don't know how Scala Steward works but here's the only reference to sbt version in `sbt/setup-sbt`.

```
inputs:
  sbt-runner-version:
    description: "The runner version (The actual version is controlled via project/build.properties)"
    required: true
    default: 1.10.3
```

https://github.com/sbt/setup-sbt/blob/0e649c9d325023db10f4c28603a7870d04c16141/action.yml#L7

Do we need to add a `build.properties` file in `sbt/setup-sbt` for Scala Steward to pick up the sbt version & update `action.yml`?