### PR TITLE
sideeffffect/liquibase-doobie

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -992,9 +992,8 @@
 - ShiftLeftSecurity/js2cpg
 - ShiftLeftSecurity/sbt-ci-release-early
 - shopstic/chopsticks
+- sideeffffect/liquibase-doobie
 - sideeffffect/sbt-decent-scala
-- sideeffffect/zio-doobie
-- sideeffffect/zio-io
 - sideeffffect/zio-testcontainers
 - sirgraystar/mandyville-modelling
 - siriusxm/snapshot4s


### PR DESCRIPTION
This is rename. zio-io is not used, so delete it.