### PR TITLE
Add `sbt/io`

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -892,6 +892,7 @@
 - sbt/sbt-web
 - sbt/sbt-web-build-base
 - sbt/setup-sbt
+- sbt/io
 - sbt/zinc
 - ScalablyTyped/Converter
 - ScalaConsultants/mesmer


### PR DESCRIPTION
@eed3si9n @SethTisue okay to go ahead?

Saw `sbt/io` still using outdated scala & sbt version. Unlike `setup-sbt` Scala Steward should handle such dependency more smoothly.