### PR TITLE
Add `sbt/librarymanagement`

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -859,6 +859,7 @@
 - sangria-graphql/sangria-subscriptions-example
 - sbt-dao-generator/sbt-dao-generator
 - sbt/io
+- sbt/librarymanagement
 - sbt/sbt-autoversion
 - sbt/sbt-avro
 - sbt/sbt-boilerplate


### PR DESCRIPTION
Similar to https://github.com/VirtusLab/scala-steward-repos/pull/473, `sbt/librarymanagement` is a standard sbt project using outdated scala / sbt version.