### PR TITLE
Add sbt/flyway-sbt

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -864,6 +864,7 @@
 - sangria-graphql/sangria-streaming-api
 - sangria-graphql/sangria-subscriptions-example
 - sbt-dao-generator/sbt-dao-generator
+- sbt/flyway-sbt
 - sbt/io
 - sbt/librarymanagement
 - sbt/sbt-autoversion


### PR DESCRIPTION
We moved this repo to the sbt org https://github.com/sbt/flyway-sbt

Thanks!