### PR TITLE
Remove deprecated set-output

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -99,7 +99,7 @@ jobs:
           LINKS="${LINKS//'%'/'%25'}"
           LINKS="${LINKS//$'\n'/'%0A'}"
           LINKS="${LINKS//$'\r'/'%0D'}"
-          echo "::set-output name=LINKS::${LINKS}"
+          echo "LINKS=${LINKS}" >> $GITHUB_OUTPUT
       - name: found diff
         id: non-empty
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
`set-output` [is now deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and should be replaced with writing to the file pointed to by `$GITHUB_OUTPUT`.