### PR TITLE
Remove zio-redis

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1232,7 +1232,6 @@
 - zio/zio-process
 - zio/zio-profiling
 - zio/zio-project-seed.g8
-- zio/zio-redis
 - zio/zio-s3
 - zio/zio-sql
 - zio/zio-sqs


### PR DESCRIPTION
It's managed by our own scala-steward bot now :)