### PR TITLE
Add the Roguelike-Starterkit to the PurpleKingdomGames group

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -811,6 +811,7 @@
 - PurpleKingdomGames/indigo
 - PurpleKingdomGames/tyrian
 - PurpleKingdomGames/ultraviolet
+- PurpleKingdomGames/roguelike-starterkit
 - quafadas/cask-laminar
 - quafadas/dedav4s
 - quafadas/scautable


### PR DESCRIPTION
The Roguelike-Starterkit is consistently released with Ultraviolet, Tyrian, and Indigo to ensure parity. It would be very helpful to have Scala Steward help keep them on the same versions.

Thanks!