### PR TITLE
remove starlake-ai/starlake

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1034,7 +1034,6 @@
 - spotify/tfreader
 - srenault/sre-api
 - stac-utils/stac4s
-- starlake-ai/starlake
 - stryker-mutator/mutation-testing-elements
 - stryker-mutator/stryker4s
 - stryker-mutator/weapon-regex


### PR DESCRIPTION
We are now running Scala Steward from our own repo. I am the repo owner.