### PR TITLE
remove bitlap/intellij-sbt-dependency-analyzer

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -108,7 +108,6 @@
 - betagouv/aplus
 - Billzabob/ForDeckmacia
 - bitcoin-s/bitcoin-s
-- bitlap/intellij-sbt-dependency-analyzer
 - bitlap/rolls
 - bitlap/smt
 - bitlap/validation-scala


### PR DESCRIPTION
It now has its own Scala Steward APP