### PR TITLE
add sbt-javaagent

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -905,6 +905,7 @@
 - sbt/sbt-gzip
 - sbt/sbt-header
 - sbt/sbt-jacoco
+- sbt/sbt-javaagent
 - sbt/sbt-java-formatter
 - sbt/sbt-jni
 - sbt/sbt-jshint


### PR DESCRIPTION
Following manual changes at https://github.com/sbt/sbt-javaagent/pull/38, I suggest Scala Steward is enabled on this repo :)