### PR TITLE
Adding Uriel, a color science library for Scala.

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -253,6 +253,7 @@
 - dragonfly-ai/narr
 - dragonfly-ai/slash
 - dragonfly-ai/spatial
+- dragonfly-ai/uriel
 - dvgica/healthful
 - dvgica/managerial
 - dvgica/periodic


### PR DESCRIPTION
Uriel brings color science to all Scala compilation targets.