### PR TITLE
remove coulomb:scala2

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -286,7 +286,6 @@
 - endpoints4s/endpoints4s
 - enlivensystems/invoicing-hungarian
 - enriquerodbe/borsh4s
-- erikerlandson/coulomb:scala2
 - erikerlandson/coulomb:scala3
 - erikvanoosten/metrics-scala
 - esamson/atbp


### PR DESCRIPTION
I am no longer actively maintaining scala2 based versions of coulomb