### PR TITLE
Remove @fd4s repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -357,8 +357,6 @@
 - evolution-gaming/stracer
 - evolution-gaming/throttler
 - Facsimiler/facsimile
-- fd4s/fs2-kafka:series/3.x
-- fd4s/vulcan
 - fdietze/bench
 - fdietze/colorado
 - fdietze/flatland


### PR DESCRIPTION
They have now been migrated to Typelevel.
- http://github.com/typelevel/fs2-kafka
- http://github.com/typelevel/vulcan