### PR TITLE
remove AnyMindGroup/zio-pubsub

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -62,7 +62,6 @@
 - ant8e/sbt-i18n
 - ant8e/uuid4cats-effect
 - anymindgroup/zio-gcp
-- anymindgroup/zio-pubsub
 - an-tex/sc8s
 - apache/daffodil
 - apache/daffodil-sbt


### PR DESCRIPTION
moved to be part of [AnyMindGroup/zio-gcp](https://github.com/AnyMindGroup/zio-gcp)