### PR TITLE
Add oluies/scala-hotwire

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -709,6 +709,7 @@
 - NthPortal/spaghetti
 - NthPortal/v
 - ocadotechnology/pass4s
+- oluies/scala-hotwire
 - OpenOlitor/openolitor-server
 - openzipkin/zipkin-finagle
 - open-electrons/open-electrons-templates


### PR DESCRIPTION
Adds my public Scala 3 / Pekko HTTP project to the list.

  - https://github.com/oluies/scala-hotwire

It's a small Hotwire (Turbo Streams) backend that demonstrates a swappable
in-process / NATS pub-sub façade. Standard sbt build, MUnit tests on JDK
21 + 25 in CI.

File sorted with `sort.sh`; only one line added.