### PR TITLE
Rename smithy-trait-codegen-scala

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -844,7 +844,7 @@
 - polyvariant/colorize-scala
 - polyvariant/respectfully
 - polyvariant/smithy4s-bsp
-- polyvariant/smithy-trait-codegen-scala
+- polyvariant/smithy-scala-tools
 - polyvariant/smithy-transformations
 - polyvariant/sttp-oauth2
 - ppurang/abctemplates


### PR DESCRIPTION
The repo was renamed so it probably still works, but I want to keep the list in sync anyway.