### PR TITLE
Add oluies/ddd-sample-scala

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -709,6 +709,7 @@
 - NthPortal/spaghetti
 - NthPortal/v
 - ocadotechnology/pass4s
+- oluies/ddd-sample-scala
 - oluies/scala-hotwire
 - OpenOlitor/openolitor-server
 - openzipkin/zipkin-finagle


### PR DESCRIPTION
Adding `oluies/ddd-sample-scala` to the Scala Steward watch list.

This is a Scala port of the [Citerus DDD Sample](https://github.com/citerus/dddsample-core) — Eric Evans' canonical cargo-shipping example, used as a teaching artifact for Domain-Driven Design tactical patterns.

- **Language:** Scala 3.3.4 LTS (just migrated from Scala 2.8)
- **Build:** sbt 1.10
- **Repo-local config:** [`.scala-steward.conf`](https://github.com/oluies/ddd-sample-scala/blob/master/.scala-steward.conf) is in place — pins `org.scala-lang` (manual migration owns Scala-version bumps), ignores deprecated `easymock`/`javassist`, and groups patches.