### PR TITLE
Update repos-github.md, remove `SwiftInvention/scala-zio-example`

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1105,7 +1105,6 @@
 - sweet-delights/delightful-edifact
 - sweet-delights/delightful-parsing
 - sweet-delights/delightful-typeclasses
-- SwiftInvention/scala-zio-example
 - SwissBorg/akka-persistence-postgres
 - SwissBorg/pekko-persistence-postgres
 - SymphonyQL/SymphonyQL


### PR DESCRIPTION
originally added by @vladimirlogachev, removing to switch to a CI-based version that also works for private repos