### PR TITLE
Modify scala-tessella from repos list

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1003,8 +1003,8 @@
 - scala-steward-org/mill-plugin
 - scala-steward-org/sbt-plugin
 - scala-steward-org/scala-steward
+- scala-tessella/dcel
 - scala-tessella/ring-seq
-- scala-tessella/tessella
 - scala-tsi/scala-tsi
 - scala-ts/scala-ts
 - scala/hello-world.g8


### PR DESCRIPTION
Added 'scala-tessella/dcel'
Removed 'scala-tessella/tessella' (superseded)