### PR TITLE
Add dfiantworks/scalapptainer

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -262,6 +262,7 @@
 - debiki/talkyard
 - delimobil/cabbit
 - DFiantHDL/DFHDL
+- dfiantworks/scalapptainer
 - dieproht/matr
 - dieproht/molly
 - dimitarg/weaver-test-extra


### PR DESCRIPTION
Adds [dfiantworks/scalapptainer](https://github.com/dfiantworks/scalapptainer) to the public Scala Steward instance.

It is a public, Mill-based Scala 3 library (a cross-platform wrapper around Apptainer) published to Maven Central. Inserted alphabetically in `repos-github.md`.