### PR TITLE
Add ProjectSidewalk/SidewalkWebpage

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -855,6 +855,7 @@
 - precog/fs2-ssh
 - precog/sbt-precog
 - profunktor/fs2-rabbit
+- ProjectSidewalk/SidewalkWebpage
 - proteinevolution/Toolkit
 - pstutz/syncodia
 - pureconfig/pureconfig


### PR DESCRIPTION
Adding [Project Sidewalk](https://github.com/ProjectSidewalk/SidewalkWebpage) — a public, open-source civic-tech web app (Scala 2.13 / Play) for crowdsourcing sidewalk-accessibility data — to the hosted Scala Steward instance so its sbt dependencies stay current. Thanks for running this service! 🙏