### PR TITLE
Replace lichess-org/playframework-lila with liplay

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -572,8 +572,7 @@
 - lichess-org/lila-openingexplorer
 - lichess-org/lila-search
 - lichess-org/lila-ws
-- lichess-org/playframework-lila
-- lichess-org/playframework-lila:scala2
+- lichess-org/liplay
 - lichess-org/scalachess
 - lichess-org/scalalib
 - lightbend-labs/benchdb


### PR DESCRIPTION
playframework-lila is a fork, so scala-steward doesn't work well with it.