### PR TITLE
Add nMoncho/sbt-osv to repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -691,6 +691,7 @@
 - nMoncho/helenus
 - nMoncho/helenus3
 - nMoncho/sbt-dependency-check
+- nMoncho/sbt-osv
 - NomadBlacky/scaladog
 - NomadBlacky/scala_examples
 - note/dhallj-magnolia


### PR DESCRIPTION
This commit add the GitHub repository: nMoncho/sbt-osv.