### PR TITLE
Rename Ragazoor/typed-future to Ragazoor/task

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -863,7 +863,7 @@
 - quafadas/dedav4s
 - quafadas/scautable
 - raboof/sbt-reproducible-builds
-- Ragazoor/typed-future
+- Ragazoor/task
 - rayrobdod/string-context-parser-combinator
 - rcmartins/blinky
 - reactivecore/datacomparison


### PR DESCRIPTION
The `Ragazoor/typed-future` repository was renamed on GitHub to `Ragazoor/task`. The old entry no longer resolves, so Scala Steward stopped opening update PRs for it. This points the listing at the new name so it's picked up again.