### PR TITLE
Update repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -172,6 +172,7 @@
 - cchantep/acolyte
 - cchantep/alohura
 - cchantep/foorgol
+- cchantep/jinbe
 - cchantep/sbt-hl-compiler
 - channingwalton/http4sWS
 - chenharryhua/nanjin
@@ -1303,7 +1304,6 @@
 - yurizhuravel/kitty
 - yurizhuravel/simple-royalties-api
 - zainab-ali/aquascape
-- zengularity/benji
 - zio/caliban-deriving
 - zio/interop-guava
 - zio/interop-monix


### PR DESCRIPTION
Remove benji ([maintenance discontinued](https://github.com/zengularity/benji/#%EF%B8%8F-maintenance-status)), in favor of jinbe