### PR TITLE
Add vlovgr/jots to repositories

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1263,6 +1263,7 @@
 - vladimirlogachev/page-title-reader-microservice
 - vladimirlogachev/transitive-closure
 - vlovgr/ciris
+- vlovgr/jots
 - vmunier/akka-http-scalajs.g8
 - vmunier/play-scalajs.g8
 - vmunier/sbt-web-scalajs


### PR DESCRIPTION
Add [jots](https://vlovgr.github.io/jots) to the list of repositories.