### PR TITLE
Remove bamboesmanager from repos-github.md

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -1084,7 +1084,6 @@
 - scodec/scodec
 - scodec/scodec-bits
 - ScoreUnder/canti-bot
-- scoutingkapelle/bamboesmanager
 - scoverage/sbt-coveralls
 - scoverage/sbt-scoverage
 - scoverage/scalac-scoverage-plugin


### PR DESCRIPTION
Removed 'scoutingkapelle/bamboesmanager' from the list.